### PR TITLE
Change glotpress URL

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -131,6 +131,9 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 define( 'NOBLOGREDIRECT', PRIMARY_SITE_URL );
 define( 'SUNRISE', true );
 
+# For translate instance
+define( 'GP_URL_BASE' , '' );
+
 // DOMAIN_CURRENT_SITE is verified to start with 'www.' later.
 define( 'INSTALLATION_ROOT_DOMAIN', preg_replace( '#^www\.#', '', DOMAIN_CURRENT_SITE ) );
 


### PR DESCRIPTION
Without that constant the url is https://translate.classicpress.net/glotpress/ better move to https://translate.classicpress.net/