### PR TITLE
Fix slug package generated by GP

### DIFF
--- a/wp-content/plugins/cp-gp-cli/inc/class-language-pack.php
+++ b/wp-content/plugins/cp-gp-cli/inc/class-language-pack.php
@@ -94,7 +94,7 @@ class Language_Pack {
 				WP_CLI::log( "Skip {$wp_locale}, translations below threshold ({$percent_translated}%)." );
 				continue;
 			}
-			
+
 			$export_directory = self::BUILD_DIR . "/{$slug}/export/{$wp_locale}";
 			$build_directory  = self::BUILD_DIR . "/{$slug}";
 			$json_directory   = self::BUILD_DIR . "/{$slug}/" . self::VERSION;


### PR DESCRIPTION
As https://github.com/ClassyBot/i18n-scripts/pull/1#issuecomment-452059333 this pr remove the slug.
In that way the endpoint will use the right package names.

### Why there was the bug
Right now CP download a package to localize CP that is in the form `core-{slug}.po/mo`.
This happened for a bug but also a confusions compared to WP. 
WordPress doesn't have only 1 file with localization but 4: (core (that doesn't have slug, admin-network (multisite), admin (dashboard) and continent-cities (all the country/languages names).

We are using (to simplify) only one localization file and because it is only one doesn't need a slug. 
This create problems on installation because `WPLANG` cannot be set in the right way because cannot find the file for the locale configured in the process.
Instead when is configured in the dashboard this force `WPLANG` to use that file with the wrong name.

### How to fix the problem for websites with the wrong package

There is a way to fix when this changes and the other pr, to the bot, will be approved:

- Remove manually this files `core-{slug}.po/mo` from `wp-content/languages`
- Reconfigure the locale from the dashboard the locale

In that way will be downloaded the right package and configured.
This procedure is for all the installation that are using a different locale then the default one.

For who want to use the beta-2 after the merge of this 2 changes that problem will no happen again.

### How many people have the issue right now

This is difficult to define because compared to WordPress we don't have the infrastructure to track this information.
Right now we have less of 10 report of this issues but with all this changes approved and this easy procedure the problem will gone.
I know that is annoying the procedure and I am sorry for the troubles and issues that this bug created.

I am working to improve the i18n team and define a better process but lucky with all this changes in progress, we can focus on adding new locales and move on the infrastructure needs.
