### PR TITLE
Fix #23, Support per-locale GlotPress admins

### DIFF
--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
@@ -6,6 +6,14 @@ class CP_GP_Assign_Locale_GlotPress {
 		add_filter( 'gp_pre_can_user', array( $this, 'pre_can_user' ), 9 , 2 );
 	}
 
+	/**
+	 * Filter to check if the current user has permissions to approve strings, based
+	 * on a role on the Rosetta site.
+	 *
+	 * @param string $verdict Verdict.
+	 * @param array  $args    Array of arguments.
+	 * @return bool True if user has permissions, false if not.
+	 */
 	public function pre_can_user( $verdict, $args ) {
 		// Logged out users have no permissions.
 		if ( ! is_user_logged_in() ) {
@@ -13,7 +21,16 @@ class CP_GP_Assign_Locale_GlotPress {
 		}
 
         $locale_and_project_id = (object) $this->get_locale_and_project_id( $args['object_type'], $args['object_id'], $args );
-        // TODO compare locale with the one of the user
+        
+        if ( ! $locale_and_project_id ) {
+            return false;
+	    }
+        
+        $gp_locale_saved = get_the_user_meta( 'gp_locale', $args[ 'user_id' ], true );
+        if ( $locale_and_project_id->locale !== $gp_locale_saved ) {
+            return false;
+        }
+        
 		// No user is allowed to delete something.
 		if ( 'delete' === $args['action'] ) {
 			return false;

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
@@ -22,29 +22,37 @@ class CP_GP_Assign_Locale_GlotPress {
 
         $locale_and_project_id = (object) $this->get_locale_and_project_id( $args['object_type'], $args['object_id'], $args );
         
+        // Get locale and current project ID.
         if ( ! $locale_and_project_id ) {
-            return false;
+             return false;
 	    }
-        
-        $gp_locale_saved = get_the_user_meta( 'gp_locale', $args[ 'user_id' ], true );
-        if ( $locale_and_project_id->locale !== $gp_locale_saved ) {
-            return false;
-        }
-        
+    
+        // Get locale and current project ID.
+        if ( ! isset( $locale_and_project_id->locale ) ) {
+             return false;
+	    }
+      
 		// No user is allowed to delete something.
 		if ( 'delete' === $args['action'] ) {
 			return false;
 		}
-
-		// Allow logged in users to submit translations.
-		if ( 'edit' == $args['action'] && 'translation-set' === $args['object_type'] ) {
-			return is_user_logged_in();
-		}
-
-		// The next checks are only for the 'approve' action, no permissions for other actions.
-		if ( 'approve' !== $args['action'] ) {
-			return false;
-		}
+        
+        // If admin you can do everything you want
+        if( current_user_can( 'administrator' ) ) { 
+            return true;
+        }
+        
+        if ( current_user_can( 'editor' ) ) {
+            // Check if the locale is different to block the permission
+            $gp_locale_saved = get_user_meta( $args[ 'user_id' ], 'gp_locale', true );
+            if ( $locale_and_project_id->locale === $gp_locale_saved ) {
+                return true;
+            }
+        }
+        
+        if ( 'edit' == $args['action'] && 'translation-set' === $args['object_type'] ) {
+	        return is_user_logged_in();
+        }
 
 		return false;
 	}
@@ -89,9 +97,9 @@ class CP_GP_Assign_Locale_GlotPress {
 			case 'project' :
 			case 'locale' :
 			case 'set-slug' :
-                $r = parse_url( $_SERVER['REQUEST_URI'] );
-                $locale = explode( '/', $r['path'] );
-                $locale = $locale[count($locale)-2];
+                $r = parse_url( $_SERVER[ 'REQUEST_URI' ] );
+                $locale = explode( '/', $r[ 'path' ] );
+                $locale = $locale[ count( $locale )-2 ];
 				return array( 'locale' => $locale, 'project_id' => (int) $object_id );
 		}
 

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
@@ -42,6 +42,11 @@ class CP_GP_Assign_Locale_GlotPress {
             return true;
         }
         
+        // The next checks are only for the 'approve' action, no permissions for other actions.
+	    if ( 'approve' !== $args['action'] ) {
+	        return false;
+	    }
+        
         if ( current_user_can( 'editor' ) ) {
             // Check if the locale is different to block the permission
             $gp_locale_saved = get_user_meta( $args[ 'user_id' ], 'gp_locale', true );

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-glotpress.php
@@ -1,0 +1,84 @@
+<?php
+
+class CP_GP_Assign_Locale_GlotPress {
+
+	function __construct() {
+		add_filter( 'gp_pre_can_user', array( $this, 'pre_can_user' ), 9 , 2 );
+	}
+
+	public function pre_can_user( $verdict, $args ) {
+		// Logged out users have no permissions.
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+        $locale_and_project_id = (object) $this->get_locale_and_project_id( $args['object_type'], $args['object_id'], $args );
+        // TODO compare locale with the one of the user
+		// No user is allowed to delete something.
+		if ( 'delete' === $args['action'] ) {
+			return false;
+		}
+
+		// Allow logged in users to submit translations.
+		if ( 'edit' == $args['action'] && 'translation-set' === $args['object_type'] ) {
+			return is_user_logged_in();
+		}
+
+		// The next checks are only for the 'approve' action, no permissions for other actions.
+		if ( 'approve' !== $args['action'] ) {
+			return false;
+		}
+
+		return false;
+	}
+	
+    /**
+	 * Extracts project ID and locale slug from object type and ID.
+	 *
+	 * @param string $object_type Current object type.
+	 * @param string $object_id   Current object ID.
+	 * @param array  $args        Optional. Array of additional arguments.
+	 * @return array|false Locale and project ID, false on failure.
+	 */
+	public function get_locale_and_project_id( $object_type, $object_id, $args = array() ) {
+		static $set_cache = array();
+
+		switch ( $object_type ) {
+			case 'translation' :
+				if ( empty( $args['extra']['translation']->translation_set_id ) ) {
+					break;
+				}
+
+				$translation_set_id = $args['extra']['translation']->translation_set_id;
+				if ( isset( $set_cache[ $translation_set_id ] ) ) {
+					$set = $set_cache[ $translation_set_id ];
+				} else {
+					$set = GP::$translation_set->get( $args['extra']['translation']->translation_set_id );
+					$set_cache[ $translation_set_id ] = $set;
+				}
+
+				return array( 'locale' => $set->locale, 'project_id' => (int) $set->project_id );
+
+			case 'translation-set' :
+				if ( isset( $set_cache[ $object_id ] ) ) {
+					$set = $set_cache[ $object_id ];
+				} else {
+					$set = GP::$translation_set->get( $object_id );
+					$set_cache[ $object_id ] = $set;
+				}
+
+				return array( 'locale' => $set->locale, 'project_id' => (int) $set->project_id );
+
+			case 'project' :
+			case 'locale' :
+			case 'set-slug' :
+                $r = parse_url( $_SERVER['REQUEST_URI'] );
+                $locale = explode( '/', $r['path'] );
+                $locale = $locale[count($locale)-2];
+				return array( 'locale' => $locale, 'project_id' => (int) $object_id );
+		}
+
+		return false;
+	}
+    
+} 

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
@@ -13,7 +13,7 @@ class CP_GP_Assign_Locale_Profile {
         $gp_project = GP::$project->by_path( "core" );
         $translation_sets = GP::$translation_set->by_project_id( $gp_project->id );
         $option = $selected = '';
-        $gp_locale_saved = get_the_author_meta( 'gp_locale', $user->ID );
+        $gp_locale_saved = get_the_user_meta( 'gp_locale', $user->ID, true );
         foreach ( $translation_sets as $set ) {
 			// Get WP locale.
 			$gp_locale = GP_Locales::by_slug( $set->locale );

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
@@ -3,13 +3,13 @@
 class CP_GP_Assign_Locale_Profile {
 
 	function __construct() {
-		add_action( 'show_user_profile', array( $this, 'crf_show_extra_profile_fields' ) );
-        add_action( 'edit_user_profile', array( $this, 'crf_show_extra_profile_fields' ) );
-        add_action( 'personal_options_update',  array( $this, 'crf_update_profile_fields' ) );
-        add_action( 'edit_user_profile_update',  array( $this, 'crf_update_profile_fields' ) );
+		add_action( 'show_user_profile', array( $this, 'show_extra_profile_fields' ) );
+        add_action( 'edit_user_profile', array( $this, 'show_extra_profile_fields' ) );
+        add_action( 'personal_options_update',  array( $this, 'update_profile_fields' ) );
+        add_action( 'edit_user_profile_update',  array( $this, 'update_profile_fields' ) );
 	}
 
-	function crf_show_extra_profile_fields( $user ) {
+	function show_extra_profile_fields( $user ) {
         $gp_project = GP::$project->by_path( "core" );
         $translation_sets = GP::$translation_set->by_project_id( $gp_project->id );
         $option = $selected = '';
@@ -46,7 +46,7 @@ class CP_GP_Assign_Locale_Profile {
         <?php
     }
     
-    function crf_update_profile_fields( $user_id ) {
+    function update_profile_fields( $user_id ) {
         if ( ! current_user_can( 'edit_user', $user_id ) ) {
             return false;
         }

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
@@ -13,7 +13,7 @@ class CP_GP_Assign_Locale_Profile {
         $gp_project = GP::$project->by_path( "core" );
         $translation_sets = GP::$translation_set->by_project_id( $gp_project->id );
         $option = $selected = '';
-        $gp_locale_saved = get_the_user_meta( 'gp_locale', $user->ID, true );
+        $gp_locale_saved = get_user_meta( $user->ID, 'gp_locale', true );
         foreach ( $translation_sets as $set ) {
 			// Get WP locale.
 			$gp_locale = GP_Locales::by_slug( $set->locale );

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
@@ -21,11 +21,11 @@ class CP_GP_Assign_Locale_Profile {
 				continue;
 			}
 			
-			if ( $gp_locale->wp_locale === $gp_locale_saved ) {
+			if ( $set->locale === $gp_locale_saved ) {
                 $selected = ' selected="selcted"';
 			}
 			
-			$option .= '<option value="' . $gp_locale->wp_locale . '"' . $selected .'>' . $gp_locale->english_name . '</option>' . "\n";
+			$option .= '<option value="' . $set->locale . '"' . $selected .'>' . $gp_locale->english_name . '</option>' . "\n";
 			$selected = '';
 			
         }

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale-profile.php
@@ -1,0 +1,59 @@
+<?php
+
+class CP_GP_Assign_Locale_Profile {
+
+	function __construct() {
+		add_action( 'show_user_profile', array( $this, 'crf_show_extra_profile_fields' ) );
+        add_action( 'edit_user_profile', array( $this, 'crf_show_extra_profile_fields' ) );
+        add_action( 'personal_options_update',  array( $this, 'crf_update_profile_fields' ) );
+        add_action( 'edit_user_profile_update',  array( $this, 'crf_update_profile_fields' ) );
+	}
+
+	function crf_show_extra_profile_fields( $user ) {
+        $gp_project = GP::$project->by_path( "core" );
+        $translation_sets = GP::$translation_set->by_project_id( $gp_project->id );
+        $option = $selected = '';
+        $gp_locale_saved = get_the_author_meta( 'gp_locale', $user->ID );
+        foreach ( $translation_sets as $set ) {
+			// Get WP locale.
+			$gp_locale = GP_Locales::by_slug( $set->locale );
+			if ( ! isset( $gp_locale->wp_locale ) ) {
+				continue;
+			}
+			
+			if ( $gp_locale->wp_locale === $gp_locale_saved ) {
+                $selected = ' selected="selcted"';
+			}
+			
+			$option .= '<option value="' . $gp_locale->wp_locale . '"' . $selected .'>' . $gp_locale->english_name . '</option>' . "\n";
+			$selected = '';
+			
+        }
+        ?>
+        <h3><?php esc_html_e( 'Set GlotPress Locale for this user' ); ?></h3>
+
+        <table class="form-table">
+            <tr>
+                <th><label for="assign_locale"><?php esc_html_e( 'User Locale' ); ?></label></th>
+                <td>
+                    <select id="assign_locale" name="gp_locale">
+                        <option value="">Please choose an option</option>
+                        <?php echo $option ?>
+                    </select>
+                </td>
+            </tr>
+        </table>
+        <?php
+    }
+    
+    function crf_update_profile_fields( $user_id ) {
+        if ( ! current_user_can( 'edit_user', $user_id ) ) {
+            return false;
+        }
+
+        if ( ! empty( esc_html( $_POST['gp_locale'] ) ) ) {
+            update_user_meta( $user_id, 'gp_locale', esc_html( $_POST['gp_locale'] ) );
+        }
+    }
+    
+} 

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin name: ClassicPress Assign Locale To Users
+ * Description: Add the locale to an user and unlock review permission based on the capabilities
+ * Version:     1.0
+ * Author:      ClassicPress.net
+ * Author URI:  http://classicpress.net
+ * License:     GPLv2 or later
+ */
+
+function cp_gp_assign_locale_profile() {
+	global $cp_gp_assign_locale_profile;
+
+	if ( ! isset( $cp_gp_assign_locale_profile ) ) {
+		include_once 'cp-gp-assign-locale-profile.php';
+		$cp_gp_assign_locale_profile = new CP_GP_Assign_Locale_Profile();
+	}
+
+	return $cp_gp_assign_locale_profile;
+}
+
+add_action( 'plugins_loaded', 'cp_gp_assign_locale_profile' );

--- a/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale.php
+++ b/wp-content/plugins/cp-gp-assign-locale/cp-gp-assign-locale.php
@@ -20,3 +20,16 @@ function cp_gp_assign_locale_profile() {
 }
 
 add_action( 'plugins_loaded', 'cp_gp_assign_locale_profile' );
+
+function cp_gp_assign_locale_glotpress() {
+	global $cp_gp_assign_locale_glotpress;
+
+	if ( ! isset( $cp_gp_assign_locale_glotpress ) ) {
+		include_once 'cp-gp-assign-locale-glotpress.php';
+		$cp_gp_assign_locale_glotpress = new CP_GP_Assign_Locale_GlotPress();
+	}
+
+	return $cp_gp_assign_locale_glotpress;
+}
+
+add_action( 'plugins_loaded', 'cp_gp_assign_locale_glotpress' );


### PR DESCRIPTION
It is a work in progress for #23.
Now we have only the field to save the locale for the user.
Next step is to use the GP filters to use this value and the capabilities of the user to check what locale he can change the locale.
